### PR TITLE
Change currentActivity setup to fix crashes

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -160,7 +160,6 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     protected void onPause() {
         super.onPause();
         if (!resettingContext) {
-            currentActivity = null;
             IntentDataHandler.onPause(getIntent());
             getReactGateway().onPauseActivity(this);
             NavigationApplication.instance.getActivityCallbacks().onActivityPaused(this);
@@ -204,7 +203,8 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     }
 
     private void destroyJsIfNeeded() {
-        if (currentActivity == null || currentActivity.isFinishing()) {
+        if (currentActivity == this || currentActivity.isFinishing()) {
+            currentActivity = null;
             getReactGateway().onDestroyApp(this);
         }
     }


### PR DESCRIPTION
This aims to fix 'Tried to use permissions API while not attached to an Activity.' bugs on bugsnag.
https://chimebank.atlassian.net/browse/CORE-1498

Step to reproduce issue:
- Get _magic*_ phone
- Install app build in release mode
- Login
- Allow location permission settings
- BUM

After this change, everything seems to work fine now.
_*magic phone - the one where this error could be reproduced, it is not obvious which one are affected_